### PR TITLE
add support for expected grokparsefailure in patterns test

### DIFF
--- a/run_example.sh
+++ b/run_example.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 echo "Running the example dir."
 echo "Logstash config is stored at example/config, test cases at example/test"
-./logstash-tester.sh -d example
+./logstash-tester.sh -d example $@

--- a/test/spec/patterns_spec.rb
+++ b/test/spec/patterns_spec.rb
@@ -15,12 +15,6 @@ pattern_data.each do |data_file|
       expected_fields = item["out"].keys
       pattern = @@test_case['pattern']
 
-      it "'#{name}' shouldn't generate grokparsefailures" do
-        match_res = grok_match(pattern, item['in'])
-        msg = "Parse failure for test case #{name}.\nComplete grok output: #{match_res}\n\n--"
-        expect(match_res).to pass, msg
-      end
-
       # Expected fields are present, have expected value, and no other fields are present
       it "'#{name}' should be correct" do
         match_res = grok_match(pattern, item['in'])


### PR DESCRIPTION
closes #1 

also adds parameter passing for `run_example.sh` so you could do `run_example.sh patterns` for example.
