### PR TITLE
allow more flexible pattern location and filter names

### DIFF
--- a/example.env
+++ b/example.env
@@ -1,0 +1,6 @@
+# these are the same values that are set in the Dockerfile.
+# Override them to change testing behavior
+RUN_CONFIGTEST=true
+TEST_TARGET=all
+PATTERN_TARGET_DIR=/etc/logstash/patterns
+FILTER_FILE_REGEX=*.filter.conf

--- a/run_example.sh
+++ b/run_example.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 echo "Running the example dir."
 echo "Logstash config is stored at example/config, test cases at example/test"
-./logstash-tester.sh -d example $@
+./logstash-tester.sh -d example

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
-if [[ $1 == "all" || $1 == "patterns" ]]; then
+if [[ $TEST_TARGET == "all" || $TEST_TARGET == "patterns" ]]; then
     echo "###  RUN PATTERN TESTS    #####################"
     rspec -f p /test/spec/patterns_spec.rb
 fi
 
-if [[ $1 == "all" || $1 == "filters" ]]; then
+if [[ $TEST_TARGET == "all" || $TEST_TARGET == "filters" ]]; then
     echo "###  RUN FILTER Tests  ####################"
-    if [[ $2 == "y" ]]; then
+    if [[ $RUN_CONFIGTEST == "true" ]]; then
         logstash --configtest -f /test/spec/filter_config
     fi
 

--- a/test/spec/filter_spec.rb
+++ b/test/spec/filter_spec.rb
@@ -7,7 +7,7 @@ require 'json'
 filter_data = Dir[File.join(File.dirname(__FILE__), 'filter_data/**/*.json')]
 
 # Load the logstash filter config files
-files = Dir[File.join(File.dirname(__FILE__), 'filter_config/*.filter.conf')]
+files = Dir[File.join(File.dirname(__FILE__), "filter_config/#{ENV['FILTER_FILE_REGEX']}")]
 @@configuration = String.new
 files.sort.each do |file|
   @@configuration << File.read(file)

--- a/test/spec/patterns_spec.rb
+++ b/test/spec/patterns_spec.rb
@@ -23,7 +23,7 @@ pattern_data.each do |data_file|
 
         # test for missing fields in match output
         missing = expected_fields.select { |f| not result_fields.include?(f) }
-        msg = "\nFields missing in pattern output: #{missing}\nComplete grok output: #{match_res}\n\n--"
+        msg = "pattern = #{pattern}\nFields missing in pattern output: #{missing}\nComplete grok output: #{match_res}\n\n--"
         expect(missing).to be_empty, msg
 
         # test for unexpected fields in match output

--- a/test/spec/spec_helper.rb
+++ b/test/spec/spec_helper.rb
@@ -23,7 +23,7 @@ module GrokHelpers
   def build_grok(label)
     grok = LogStash::Filters::Grok.new("match" => ["message", "%{#{label}}"])
     # Manually set patterns_dir so that grok finds them when we're testing patterns
-    grok.patterns_dir = ["/etc/logstash/patterns"]
+    grok.patterns_dir = [ENV["PATTERN_TARGET_DIR"]]
     grok.register
     grok
   end


### PR DESCRIPTION
Not sure if you'll like this or not :-)  Happy to discuss the details of what I did here.  I've basically leveraged the environment variable functionality of `docker run` to pass in some of the things that were previously flags to `logstash-tester.sh`, and added a couple more that address issue #5.

The `run_example.sh` works for me, and as an added bonus, I've been able to also run a test suite for my application that uses a different patterns location and filter nameing convention.  Pretty exciting stuff!

I wish there was a way to pass in build_args via a file to `docker run`.  I think that would eliminate the need for the convenience scripts like `run_example.sh`.

Let me know what you think.

Closes: #5 
